### PR TITLE
fix: doc_id number in get_user_threads

### DIFF
--- a/threads_api/src/threads_api.py
+++ b/threads_api/src/threads_api.py
@@ -311,7 +311,7 @@ class ThreadsAPI:
                         'userID': user_id,
                     }
                 ),
-                'doc_id': '6307072669391286'
+                'doc_id': '6232751443445612'
             }
         
         async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
The doc_id variable was the same for get threads reply, now have the correct id's each function and display their related threads.